### PR TITLE
feat: Optional invocation receipts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rollup -c",
     "prepack": "npm run build",
     "preversion": "npm run build && npm run test",
-    "test": "lab -fSv --globals globalThis --pattern **/*.ts --transform ./test/lib/typescript.js"
+    "test": "lab -fSv --globals globalThis --transform ./test/lib/typescript.js"
   },
   "keywords": [],
   "author": "Geoff Goodman <geoff@goodman.dev> (https://geoff@goodman.dev)",

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -1,6 +1,6 @@
 import { WrappedType, WrappedError, WrappedFunction } from './types';
-
-const resolvedPromise = Promise.resolve();
+import { Thenable } from 'ts-primitives';
+import { resolvedPromise } from './constants';
 
 export interface Codec<
   TName extends string = string,
@@ -47,7 +47,7 @@ export class FunctionCodec implements Codec<'Function', (...args: any[]) => any,
     private readonly invokeRemoteAnonymousFunction: (
       anonymousFunctionId: number,
       ...args: unknown[]
-    ) => Promise<unknown>
+    ) => Thenable<unknown>
   ) {}
 
   canEncode(obj: unknown) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const resolvedPromise = Promise.resolve();

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export function isIncomingAnonymousFunctionInvocation(
     msg[0] === 0 &&
     typeof msg[1] === 'number' &&
     Number.isInteger(msg[1]) &&
-    msg[1] > 0 &&
+    msg[1] >= 0 &&
     typeof msg[2] === 'number' &&
     Number.isInteger(msg[2])
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,4 @@
-export type AnonymousFunctionInvocation = [0, number, number, ...unknown[]];
-export type AnonymousFunctionResponse = [0, number, null | WrappedError, unknown[]];
-export type InvocationMessage = [number, string, ...unknown[]];
+export type InvocationMessage = [number, string | number, ...unknown[]];
 export type ResponseMessage = [number, null | WrappedError, unknown];
 export type WrappedType<T extends string> = { $: T };
 
@@ -13,35 +11,16 @@ export interface WrappedFunction extends WrappedType<'Function'> {
   id: number;
 }
 
-export function isIncomingAnonymousFunctionInvocation(
-  msg: unknown[]
-): msg is AnonymousFunctionInvocation {
-  return (
-    msg[0] === 0 &&
-    typeof msg[1] === 'number' &&
-    Number.isInteger(msg[1]) &&
-    msg[1] >= 0 &&
-    typeof msg[2] === 'number' &&
-    Number.isInteger(msg[2])
-  );
-}
-
-export function isIncomingAnonymousFunctionResponse(
-  msg: unknown[]
-): msg is AnonymousFunctionResponse {
-  return (
-    msg[0] === 0 &&
-    typeof msg[1] === 'number' &&
-    Number.isInteger(msg[1]) &&
-    msg[1] < 0 &&
-    (msg[2] === null || isWrappedError(msg[2]))
-  );
-}
-
 export function isIncomingInvocationMessage(msg: unknown[]): msg is InvocationMessage {
   const [id, methodName] = msg;
 
-  return typeof id === 'number' && Number.isInteger(id) && id > 0 && typeof methodName === 'string';
+  return (
+    typeof id === 'number' &&
+    Number.isInteger(id) &&
+    id >= 0 &&
+    (typeof methodName === 'string' ||
+      (typeof methodName === 'number' && Number.isInteger(methodName) && methodName > 0))
+  );
 }
 
 export function isIncomingResponseMessage(msg: unknown[]): msg is ResponseMessage {
@@ -74,13 +53,3 @@ export function isWrappedTypeOfKind<T extends string>(
 ): obj is WrappedType<T> {
   return isWrappedType(obj) && obj.$ === type;
 }
-
-type Primitive = string | number | boolean | null | undefined | void;
-type ExposedFunction<
-  T extends (...args: any[]) => any,
-  TArgs = Parameters<T>,
-  TReturn = ReturnType<T>
-> = TArgs extends Primitive[] ? (TReturn extends Primitive ? T : never) : never;
-
-type Test = (n: number) => number;
-type Result = ExposedFunction<Test>;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,12 @@
-export function dfdForReq<T>() {
+import { Thenable } from 'ts-primitives';
+
+export interface Deferred<T> {
+  resolve(result: T | Promise<T> | Thenable<T>): void;
+  reject(err: Error): void;
+  promise: Promise<T>;
+}
+
+export function createDeferred<T>(): Deferred<T> {
   let settled = false;
 
   const op = {
@@ -23,4 +31,10 @@ export function dfdForReq<T>() {
   });
 
   return op;
+}
+
+export function thenableAlreadySettled() {
+  throw new TypeError(
+    'Attempted to wait on the outcome of an rpc request after it was sent without requesting a delivery receipt'
+  );
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,7 @@
-export function dfdForReq<T>(reqId: number) {
+export function dfdForReq<T>() {
   let settled = false;
 
   const op = {
-    reqId,
     resolve: (undefined as unknown) as (result: any) => void,
     reject: (undefined as unknown) as (err: Error) => void,
     promise: (undefined as unknown) as Promise<T>,

--- a/test/index.ts
+++ b/test/index.ts
@@ -82,7 +82,7 @@ describe('The end to end protocol', () => {
     const leftApi = {
       doWork: async (log: (n: number) => void) => {
         for (let i = 0; i < times; i++) {
-          await log(i);
+          log(i);
         }
       },
     };


### PR DESCRIPTION
## Requirements

* Users of this library want to write idiomatic code so that this library doesn't contaminate their codebase with new paradigms or requirements.
* Users of this library should be able to interact with peers using the same code that would be used if the peer's logic was running locally.
* Users may wish to use this library for `Promise`-based or node-style-callback-based logic (or a mix thereof). This library should not require its users to annotate calls and anonymous functions to signal intentions to the library. This would make the library 'contagious'.

## Motivation

Given the above considerations, we can expect a mix of Promise-using and callback-using applications using this library. The issue is that to support `Promise-using` applications of this library, we need to send "delivery receipts" for every function invocation. That has the potential to double the number of messages and affect performance.

**To avoid the performance hit of delivery receipts, this PR attempts to use the semantics of javascript "thenables" to only request delivery receipts when needed _and without requiring additional channels to signal this requirement_.**

## Design

Uses a new pattern, I would call a 'lazy thenable' to determine whether delivery receipts should be sent for the completion of remote anonymous function invocations. It works like this:

- Return a `Thenable` to the caller of a local proxy function for a remote anonymous function.
- Defer sending the request over the wire until the _END_ of the next microtask queue (`resolvedPromise.then(() => resolvedPromise.then(() => { /* deferred logic */ }))`).
- Check if the `.then` method of the `Thenable` was called when running the deferred function:
  - If it was, generate a new anonymous request id and store a `Deferred` object for it. Send an anonymous function invocation over the transport with a `reqId > 0`.
  - If it wasn't, assume that no delivery receipt is needed and send an anonymous function invocation over the transport with a `reqId === 0`.

https://github.com/ggoodman/rpc/blob/42a7dda1163cfba4d99d004ec3c7a287f0bf5f9c/src/peer.ts#L160-L190

Trade-offs:
1. It is not guaranteed that code that intends to wait on a delivery receipt will have done so by the end of the next microtask queue. However, code that fails to do so, would implicitly also be _dangerous_ code that is likely to produce unhandled promise rejections.
2. It defers the _sending_ of anonymous function request messages to the _END_ of the next microtask queue, adding latency. It seems like a good tradeoff because it will reduce overall _work_ for anonymous function invocations that don't need it.